### PR TITLE
DR-312: Add OpenID support for integrations

### DIFF
--- a/Dwolla.Client/Dwolla.Client.csproj
+++ b/Dwolla.Client/Dwolla.Client.csproj
@@ -3,12 +3,12 @@
     <TargetFramework>netstandard1.3</TargetFramework>
     <Company>Dwolla, Inc.</Company>
     <!-- Also update UserAgent version in DwollaClient.cs -->
-    <AssemblyVersion>5.1.1</AssemblyVersion>
-    <FileVersion>5.1.1</FileVersion>
-    <Version>5.1.1</Version>
+    <AssemblyVersion>6.0.0</AssemblyVersion>
+    <FileVersion>6.0.0</FileVersion>
+    <Version>6.0.0</Version>
     <Authors>Dwolla, Inc</Authors>
     <Description>Official C# Wrapper for Dwolla's API v2</Description>
-    <Copyright>Copyright © 2018 Dwolla, Inc</Copyright>
+    <Copyright>Copyright © 2019 Dwolla, Inc</Copyright>
     <PackageProjectUrl>https://github.com/Dwolla/dwolla-v2-csharp</PackageProjectUrl>
     <PackageIconUrl>https://dashboard.dwolla.com/static/icons/android-chrome-192x192.png</PackageIconUrl>
     <PackageTags>dwolla api payments bank transfers money ach sdk</PackageTags>

--- a/Dwolla.Client/DwollaClient.cs
+++ b/Dwolla.Client/DwollaClient.cs
@@ -14,131 +14,145 @@ using Dwolla.Client.Rest;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 
-[assembly: InternalsVisibleTo("Dwolla.Client.Tests")]
+[assembly : InternalsVisibleTo ("Dwolla.Client.Tests")]
 
-namespace Dwolla.Client
-{
-    public interface IDwollaClient
-    {
+namespace Dwolla.Client {
+    public interface IDwollaClient {
         string ApiBaseAddress { get; }
         string AuthBaseAddress { get; }
-
-        Task<RestResponse<TRes>> PostAuthAsync<TRes>(Uri uri, AppTokenRequest content) where TRes : IDwollaResponse;
-        Task<RestResponse<TRes>> GetAsync<TRes>(Uri uri, Headers headers) where TRes : IDwollaResponse;
-        Task<RestResponse<TRes>> PostAsync<TReq, TRes>(Uri uri, TReq content, Headers headers) where TRes : IDwollaResponse;
-        Task<RestResponse<EmptyResponse>> DeleteAsync<TReq>(Uri uri, TReq content, Headers headers);
-        Task<RestResponse<EmptyResponse>> UploadAsync(Uri uri, UploadDocumentRequest content, Headers headers);
+        Task<RestResponse<TRes>> PostAuthAsync<TRes> (AppTokenRequest content) where TRes : IDwollaResponse;
+        Task<RestResponse<TRes>> PostAuthAsync<TRes> (AuthorizationCodeRequest content) where TRes : IDwollaResponse;
+        Task<RestResponse<TRes>> PostAuthAsync<TRes> (RefreshTokenRequest content) where TRes : IDwollaResponse;
+        Task<RestResponse<TRes>> GetAsync<TRes> (Uri uri, Headers headers) where TRes : IDwollaResponse;
+        Task<RestResponse<TRes>> PostAsync<TReq, TRes> (Uri uri, TReq content, Headers headers) where TRes : IDwollaResponse;
+        Task<RestResponse<EmptyResponse>> DeleteAsync<TReq> (Uri uri, TReq content, Headers headers);
+        Task<RestResponse<EmptyResponse>> UploadAsync (Uri uri, UploadDocumentRequest content, Headers headers);
     }
 
-    public class DwollaClient : IDwollaClient
-    {
+    public class DwollaClient : IDwollaClient {
         public const string ContentType = "application/vnd.dwolla.v1.hal+json";
         public string ApiBaseAddress { get; }
         public string AuthBaseAddress { get; }
 
         private static readonly JsonSerializerSettings JsonSettings =
-            new JsonSerializerSettings
-            {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            new JsonSerializerSettings {
+                ContractResolver = new CamelCasePropertyNamesContractResolver (),
                 NullValueHandling = NullValueHandling.Ignore
             };
 
         private readonly IRestClient _client;
+        
+        public static DwollaClient Create (bool isSandbox) =>
+            new DwollaClient (new RestClient (CreateHttpClient ()), isSandbox);
 
-        public static DwollaClient Create(bool isSandbox) =>
-            new DwollaClient(new RestClient(CreateHttpClient()), isSandbox);
-
-        public async Task<RestResponse<TRes>> PostAuthAsync<TRes>(
-            Uri uri, AppTokenRequest content) where TRes : IDwollaResponse =>
-            await SendAsync<TRes>(new HttpRequestMessage(HttpMethod.Post, uri)
-            {
-                Content = new FormUrlEncodedContent(new Dictionary<string, string>
-                {
-                    {"client_id", content.Key}, {"client_secret", content.Secret}, {"grant_type", content.GrantType}
+        public async Task<RestResponse<TRes>> PostAuthAsync<TRes> (AppTokenRequest content) where TRes : IDwollaResponse =>
+            await SendAsync<TRes> (AuthenticateRequest (new HttpRequestMessage (HttpMethod.Post, TokenUri()) {
+                Content = new FormUrlEncodedContent (new Dictionary<string, string> { { "grant_type", content.GrantType }
                 })
-            });
+            }, content.Key, content.Secret));
 
-        public async Task<RestResponse<TRes>> GetAsync<TRes>(
-            Uri uri, Headers headers) where TRes : IDwollaResponse =>
-            await SendAsync<TRes>(CreateRequest(HttpMethod.Get, uri, headers));
+        public async Task<RestResponse<TRes>> PostAuthAsync<TRes> (AuthorizationCodeRequest content) where TRes : IDwollaResponse =>
+            await SendAsync<TRes> (AuthenticateRequest (new HttpRequestMessage (HttpMethod.Post, TokenUri()) {
+                Content = new FormUrlEncodedContent (new Dictionary<string, string> { { "grant_type", content.GrantType },
+                    { "code", content.Code },
+                    { "redirect_uri", content.RedirectUri }
+                })
+            }, content.Key, content.Secret));
 
-        public async Task<RestResponse<TRes>> PostAsync<TReq, TRes>(
-            Uri uri, TReq content, Headers headers) where TRes : IDwollaResponse =>
-            await SendAsync<TRes>(CreatePostRequest(uri, content, headers));
+        public async Task<RestResponse<TRes>> PostAuthAsync<TRes> (RefreshTokenRequest content) where TRes : IDwollaResponse =>
+            await SendAsync<TRes> (AuthenticateRequest (new HttpRequestMessage (HttpMethod.Post, TokenUri()) {
+                Content = new FormUrlEncodedContent (new Dictionary<string, string> { { "grant_type", content.GrantType },
+                    { "refresh_token", content.RefreshToken }
+                })
+            }, content.Key, content.Secret));
 
-        public async Task<RestResponse<EmptyResponse>> UploadAsync(
-            Uri uri, UploadDocumentRequest content, Headers headers) =>
-            await SendAsync<EmptyResponse>(CreateUploadRequest(uri, content, headers));
+        public async Task<RestResponse<TRes>> GetAsync<TRes> (
+                Uri uri, Headers headers) where TRes : IDwollaResponse =>
+            await SendAsync<TRes> (CreateRequest (HttpMethod.Get, uri, headers));
 
-        public async Task<RestResponse<EmptyResponse>> DeleteAsync<TReq>(Uri uri, TReq content, Headers headers) =>
-            await SendAsync<EmptyResponse>(CreateDeleteRequest(uri, content, headers));
+        public async Task<RestResponse<TRes>> PostAsync<TReq, TRes> (
+                Uri uri, TReq content, Headers headers) where TRes : IDwollaResponse =>
+            await SendAsync<TRes> (CreatePostRequest (uri, content, headers));
 
-        private async Task<RestResponse<TRes>> SendAsync<TRes>(HttpRequestMessage request) =>
-            await _client.SendAsync<TRes>(request);
+        public async Task<RestResponse<EmptyResponse>> UploadAsync (
+                Uri uri, UploadDocumentRequest content, Headers headers) =>
+            await SendAsync<EmptyResponse> (CreateUploadRequest (uri, content, headers));
 
-        private static HttpRequestMessage CreateDeleteRequest<TReq>(
-            Uri requestUri, TReq content, Headers headers, string contentType = ContentType) =>
-            CreateContentRequest(HttpMethod.Delete, requestUri, headers, content, contentType);
+        public async Task<RestResponse<EmptyResponse>> DeleteAsync<TReq> (Uri uri, TReq content, Headers headers) =>
+            await SendAsync<EmptyResponse> (CreateDeleteRequest (uri, content, headers));
 
-        private static HttpRequestMessage CreatePostRequest<TReq>(
-            Uri requestUri, TReq content, Headers headers, string contentType = ContentType) =>
-            CreateContentRequest(HttpMethod.Post, requestUri, headers, content, contentType);
+        private async Task<RestResponse<TRes>> SendAsync<TRes> (HttpRequestMessage request) =>
+            await _client.SendAsync<TRes> (request);
 
-        private static HttpRequestMessage CreateContentRequest<TReq>(
-            HttpMethod method, Uri requestUri, Headers headers, TReq content, string contentType)
-        {
-            var r = CreateRequest(method, requestUri, headers);
-            r.Content = new StringContent(JsonConvert.SerializeObject(content, JsonSettings), Encoding.UTF8, contentType);
+        private static HttpRequestMessage CreateDeleteRequest<TReq> (
+                Uri requestUri, TReq content, Headers headers, string contentType = ContentType) =>
+            CreateContentRequest (HttpMethod.Delete, requestUri, headers, content, contentType);
+
+        private static HttpRequestMessage CreatePostRequest<TReq> (
+                Uri requestUri, TReq content, Headers headers, string contentType = ContentType) =>
+            CreateContentRequest (HttpMethod.Post, requestUri, headers, content, contentType);
+
+        private static HttpRequestMessage CreateContentRequest<TReq> (
+            HttpMethod method, Uri requestUri, Headers headers, TReq content, string contentType) {
+            var r = CreateRequest (method, requestUri, headers);
+            r.Content = new StringContent (JsonConvert.SerializeObject (content, JsonSettings), Encoding.UTF8, contentType);
             return r;
         }
 
-        private static HttpRequestMessage CreateUploadRequest(Uri requestUri, UploadDocumentRequest content,
-            Headers headers)
-        {
-            var r = CreateRequest(HttpMethod.Post, requestUri, headers);
-            r.Content = new MultipartFormDataContent("----------Upload")
-            {
-                {new StringContent(content.DocumentType), "\"documentType\""},
-                GetFileContent(content.Document)
+        private static HttpRequestMessage CreateUploadRequest (Uri requestUri, UploadDocumentRequest content,
+            Headers headers) {
+            var r = CreateRequest (HttpMethod.Post, requestUri, headers);
+            r.Content = new MultipartFormDataContent ("----------Upload") { { new StringContent (content.DocumentType), "\"documentType\"" },
+                GetFileContent (content.Document)
             };
             return r;
         }
 
-        private static StreamContent GetFileContent(File file)
-        {
-            var fc = new StreamContent(file.Stream);
-            fc.Headers.ContentType = MediaTypeHeaderValue.Parse(file.ContentType);
-            fc.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
-            {
+        private static StreamContent GetFileContent (File file) {
+            var fc = new StreamContent (file.Stream);
+            fc.Headers.ContentType = MediaTypeHeaderValue.Parse (file.ContentType);
+            fc.Headers.ContentDisposition = new ContentDispositionHeaderValue ("form-data") {
                 Name = "\"file\"",
                 FileName = $"\"{file.Filename}\""
             };
             return fc;
         }
 
-        private static HttpRequestMessage CreateRequest(HttpMethod method, Uri requestUri, Headers headers)
-        {
-            var r = new HttpRequestMessage(method, requestUri);
-            r.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(ContentType));
-            foreach (var header in headers) r.Headers.Add(header.Key, header.Value);
+        private static HttpRequestMessage CreateRequest (HttpMethod method, Uri requestUri, Headers headers) {
+            var r = new HttpRequestMessage (method, requestUri);
+            r.Headers.Accept.Add (new MediaTypeWithQualityHeaderValue (ContentType));
+            foreach (var header in headers) r.Headers.Add (header.Key, header.Value);
             return r;
         }
 
-        internal DwollaClient(IRestClient client, bool isSandbox)
-        {
+        internal DwollaClient (IRestClient client, bool isSandbox) {
             _client = client;
             ApiBaseAddress = isSandbox ? "https://api-sandbox.dwolla.com" : "https://api.dwolla.com";
             AuthBaseAddress = isSandbox ? "https://accounts-sandbox.dwolla.com" : "https://accounts.dwolla.com";
         }
 
-        private static readonly string ClientVersion = typeof(DwollaClient).GetTypeInfo().Assembly
-            .GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+        private static readonly string ClientVersion = typeof (DwollaClient).GetTypeInfo ().Assembly
+            .GetCustomAttribute<AssemblyFileVersionAttribute> ().Version;
 
-        internal static HttpClient CreateHttpClient()
-        {
-            var client = new HttpClient(new HttpClientHandler {SslProtocols = SslProtocols.Tls12});
-            client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("dwolla-v2-csharp", ClientVersion));
+        internal static HttpClient CreateHttpClient () {
+            var client = new HttpClient (new HttpClientHandler { SslProtocols = SslProtocols.Tls12 });
+            client.DefaultRequestHeaders.UserAgent.Add (new ProductInfoHeaderValue ("dwolla-v2-csharp", ClientVersion));
             return client;
+        }
+
+        private Uri TokenUri()
+        {
+            return new Uri($"{ApiBaseAddress}/token");
+        }
+        
+        private HttpRequestMessage AuthenticateRequest (
+            HttpRequestMessage request, string clientId, string clientSecret
+        ) {
+            var base64Creds = Convert.ToBase64String (
+                Encoding.ASCII.GetBytes ($"{clientId}:{clientSecret}")
+            );
+            request.Headers.Add ("Authorization", $"Basic {base64Creds}");
+            return request;
         }
     }
 }

--- a/Dwolla.Client/Models/Requests/AuthorizationCodeRequest.cs
+++ b/Dwolla.Client/Models/Requests/AuthorizationCodeRequest.cs
@@ -1,0 +1,9 @@
+namespace Dwolla.Client.Models.Requests {
+    public class AuthorizationCodeRequest {
+        public string Key { get; set; }
+        public string Secret { get; set; }
+        public string Code { get; set; }
+        public string RedirectUri { get; set; }
+        public string GrantType => "authorization_code";
+    }
+}

--- a/Dwolla.Client/Models/Requests/RefreshTokenRequest.cs
+++ b/Dwolla.Client/Models/Requests/RefreshTokenRequest.cs
@@ -1,0 +1,8 @@
+namespace Dwolla.Client.Models.Requests {
+    public class RefreshTokenRequest {
+        public string Key { get; set; }
+        public string Secret { get; set; }
+        public string RefreshToken { get; set; }
+        public string GrantType => "refresh_token";
+    }
+}

--- a/Dwolla.Client/Models/Responses/TokenResponse.cs
+++ b/Dwolla.Client/Models/Responses/TokenResponse.cs
@@ -1,28 +1,29 @@
 ﻿using Newtonsoft.Json;
 
-namespace Dwolla.Client.Models.Responses
-{
-    public class TokenResponse : IDwollaResponse
-    {
-        [JsonProperty(PropertyName = "access_token")]
+namespace Dwolla.Client.Models.Responses {
+    public class TokenResponse : IDwollaResponse {
+        [JsonProperty (PropertyName = "access_token")]
         public string Token { get; set; }
 
-        [JsonProperty(PropertyName = "expires_in")]
+        [JsonProperty (PropertyName = "id_token")]
+        public string IdToken { get; set; }
+
+        [JsonProperty (PropertyName = "expires_in")]
         public int ExpiresIn { get; set; }
 
-        [JsonProperty(PropertyName = "refresh_token")]
+        [JsonProperty (PropertyName = "refresh_token")]
         public string RefreshToken { get; set; }
 
-        [JsonProperty(PropertyName = "refresh_expires_in")]
+        [JsonProperty (PropertyName = "refresh_expires_in")]
         public int RefreshExpiresIn { get; set; }
 
-        [JsonProperty(PropertyName = "token_type")]
+        [JsonProperty (PropertyName = "token_type")]
         public string TokenType { get; set; }
 
-        [JsonProperty(PropertyName = "error")]
+        [JsonProperty (PropertyName = "error")]
         public string Error { get; set; }
 
-        [JsonProperty(PropertyName = "error_description")]
+        [JsonProperty (PropertyName = "error_description")]
         public string ErrorDescription { get; set; }
     }
 }

--- a/ExampleApp/DwollaBroker.cs
+++ b/ExampleApp/DwollaBroker.cs
@@ -7,209 +7,190 @@ using Dwolla.Client.Models.Requests;
 using Dwolla.Client.Models.Responses;
 using Dwolla.Client.Rest;
 
-namespace ExampleApp
-{
-    internal class DwollaBroker
-    {
-        private readonly Headers _headers = new Headers();
+namespace ExampleApp {
+    internal class DwollaBroker {
+        private readonly Headers _headers = new Headers ();
         private readonly IDwollaClient _client;
 
-        internal DwollaBroker(IDwollaClient client) => _client = client;
+        internal DwollaBroker (IDwollaClient client) => _client = client;
 
-        internal async Task<TokenResponse> SetAuthorizationHeader(string key, string secret)
-        {
-            var response = await _client.PostAuthAsync<TokenResponse>(
-                new Uri($"{_client.AuthBaseAddress}/token"), new AppTokenRequest {Key = key, Secret = secret});
+        internal async Task<TokenResponse> SetAuthorizationHeader (string key, string secret) {
+            var response = await _client.PostAuthAsync<TokenResponse> (new AppTokenRequest { Key = key, Secret = secret });
 
             // TODO: Securely store token in your database for reuse
-            if (!_headers.ContainsKey("Authorization"))
-                _headers.Add("Authorization", $"Bearer {response.Content.Token}");
-            else
-                _headers["Authorization"] = $"Bearer {response.Content.Token}";
+            SetBearerAuthorization (response.Content.Token);
 
             return response.Content;
         }
 
-        internal async Task<RootResponse> GetRootAsync() =>
-            (await GetAsync<RootResponse>(new Uri(_client.ApiBaseAddress))).Content;
+        internal void SetBearerAuthorization (string token) {
+            if (!_headers.ContainsKey ("Authorization"))
+                _headers.Add ("Authorization", $"Bearer {token}");
+            else
+                _headers["Authorization"] = $"Bearer {token}";
+        }
 
-        internal async Task<Uri> CreateBeneficialOwnerAsync(Uri uri, CreateBeneficialOwnerRequest request)
-        {
-            var response = await PostAsync(uri, request);
+        internal async Task<RootResponse> GetRootAsync () =>
+            (await GetAsync<RootResponse> (new Uri (_client.ApiBaseAddress))).Content;
+
+        internal async Task<Uri> CreateBeneficialOwnerAsync (Uri uri, CreateBeneficialOwnerRequest request) {
+            var response = await PostAsync (uri, request);
             return response.Response.Headers.Location;
         }
 
-        internal async Task<GetBeneficialOwnersResponse> GetBeneficialOwnersAsync(Uri uri) =>
-            (await GetAsync<GetBeneficialOwnersResponse>(uri)).Content;
+        internal async Task<GetBeneficialOwnersResponse> GetBeneficialOwnersAsync (Uri uri) =>
+            (await GetAsync<GetBeneficialOwnersResponse> (uri)).Content;
 
-        internal async Task<BeneficialOwnerResponse> GetBeneficialOwnerAsync(Uri uri) =>
-            (await GetAsync<BeneficialOwnerResponse>(uri)).Content;
+        internal async Task<BeneficialOwnerResponse> GetBeneficialOwnerAsync (Uri uri) =>
+            (await GetAsync<BeneficialOwnerResponse> (uri)).Content;
 
-        internal async Task DeleteBeneficialOwnerAsync(string id) =>
-            await DeleteAsync<object>(new Uri($"{_client.ApiBaseAddress}/beneficial-owners/{id}"), null);
+        internal async Task DeleteBeneficialOwnerAsync (string id) =>
+            await DeleteAsync<object> (new Uri ($"{_client.ApiBaseAddress}/beneficial-owners/{id}"), null);
 
-        internal async Task<BeneficialOwnershipResponse> GetBeneficialOwnershipAsync(Uri uri) =>
-            (await GetAsync<BeneficialOwnershipResponse>(uri)).Content;
+        internal async Task<BeneficialOwnershipResponse> GetBeneficialOwnershipAsync (Uri uri) =>
+            (await GetAsync<BeneficialOwnershipResponse> (uri)).Content;
 
-        internal async Task<Uri> CertifyBeneficialOwnershipAsync(Uri uri) =>
-            (await PostAsync(uri, new CertifyBeneficialOwnershipRequest {Status = "certified"})).Response.Headers.Location;
+        internal async Task<Uri> CertifyBeneficialOwnershipAsync (Uri uri) =>
+            (await PostAsync (uri, new CertifyBeneficialOwnershipRequest { Status = "certified" })).Response.Headers.Location;
 
-        internal async Task<Uri> CreateCustomerAsync(Uri uri, string firstName, string lastName, string email) =>
-            await CreateCustomerAsync(uri, new CreateCustomerRequest
-            {
+        internal async Task<Uri> CreateCustomerAsync (Uri uri, string firstName, string lastName, string email) =>
+            await CreateCustomerAsync (uri, new CreateCustomerRequest {
                 FirstName = firstName,
-                LastName = lastName,
-                Email = email
+                    LastName = lastName,
+                    Email = email
             });
 
-        internal async Task<Uri> CreateCustomerAsync(Uri uri, CreateCustomerRequest request)
-        {
-            var r = await PostAsync<CreateCustomerRequest, EmptyResponse>(uri, request);
+        internal async Task<Uri> CreateCustomerAsync (Uri uri, CreateCustomerRequest request) {
+            var r = await PostAsync<CreateCustomerRequest, EmptyResponse> (uri, request);
             return r.Response.Headers.Location;
         }
 
-        internal async Task<Uri> UploadDocumentAsync(Uri uri, UploadDocumentRequest request) =>
-            (await ExecAsync(() => _client.UploadAsync(uri, request, _headers))).Response.Headers.Location;
+        internal async Task<Uri> UploadDocumentAsync (Uri uri, UploadDocumentRequest request) =>
+            (await ExecAsync (() => _client.UploadAsync (uri, request, _headers))).Response.Headers.Location;
 
-        internal async Task<Customer> UpdateCustomerAsync(Uri uri, UpdateCustomerRequest request) =>
-            (await PostAsync<UpdateCustomerRequest, Customer>(uri, request)).Content;
+        internal async Task<Customer> UpdateCustomerAsync (Uri uri, UpdateCustomerRequest request) =>
+            (await PostAsync<UpdateCustomerRequest, Customer> (uri, request)).Content;
 
-        internal async Task<Customer> GetCustomerAsync(Uri uri) => (await GetAsync<Customer>(uri)).Content;
+        internal async Task<Customer> GetCustomerAsync (Uri uri) => (await GetAsync<Customer> (uri)).Content;
 
-        internal async Task<GetCustomersResponse> GetCustomersAsync(Uri uri) =>
-            (await GetAsync<GetCustomersResponse>(uri)).Content;
+        internal async Task<GetCustomersResponse> GetCustomersAsync (Uri uri) =>
+            (await GetAsync<GetCustomersResponse> (uri)).Content;
 
-        internal async Task<GetDocumentsResponse> GetCustomerDocumentsAsync(Uri customerUri) =>
-            (await GetAsync<GetDocumentsResponse>(new Uri(customerUri.AbsoluteUri + "/documents"))).Content;
+        internal async Task<GetDocumentsResponse> GetCustomerDocumentsAsync (Uri customerUri) =>
+            (await GetAsync<GetDocumentsResponse> (new Uri (customerUri.AbsoluteUri + "/documents"))).Content;
 
-        internal async Task<GetFundingSourcesResponse> GetCustomerFundingSourcesAsync(Uri customerUri) =>
-            (await GetAsync<GetFundingSourcesResponse>(new Uri(customerUri.AbsoluteUri + "/funding-sources"))).Content;
+        internal async Task<GetFundingSourcesResponse> GetCustomerFundingSourcesAsync (Uri customerUri) =>
+            (await GetAsync<GetFundingSourcesResponse> (new Uri (customerUri.AbsoluteUri + "/funding-sources"))).Content;
 
-        internal async Task<FundingSource> GetFundingSourceAsync(string fundingSourceId) =>
-            (await GetAsync<FundingSource>(new Uri($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}"))).Content;
+        internal async Task<FundingSource> GetFundingSourceAsync (string fundingSourceId) =>
+            (await GetAsync<FundingSource> (new Uri ($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}"))).Content;
 
-        internal async Task<MicroDepositsResponse> GetMicroDepositsAsync(string fundingSourceId) =>
-            (await GetAsync<MicroDepositsResponse>(
-                new Uri($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}/micro-deposits"))).Content;
+        internal async Task<MicroDepositsResponse> GetMicroDepositsAsync (string fundingSourceId) =>
+            (await GetAsync<MicroDepositsResponse> (
+                new Uri ($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}/micro-deposits"))).Content;
 
-        internal async Task<Uri> VerifyMicroDepositsAsync(string fundingSourceId, decimal amount1, decimal amount2) =>
-            (await PostAsync(new Uri($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}/micro-deposits"),
-                new MicroDepositsRequest
-                {
-                    Amount1 = new Money {Value = amount1, Currency = "USD"},
-                    Amount2 = new Money {Value = amount2, Currency = "USD"}
+        internal async Task<Uri> VerifyMicroDepositsAsync (string fundingSourceId, decimal amount1, decimal amount2) =>
+            (await PostAsync (new Uri ($"{_client.ApiBaseAddress}/funding-sources/{fundingSourceId}/micro-deposits"),
+                new MicroDepositsRequest {
+                    Amount1 = new Money { Value = amount1, Currency = "USD" },
+                        Amount2 = new Money { Value = amount2, Currency = "USD" }
                 })).Response.Headers.Location;
 
+        internal async Task<BalanceResponse> GetFundingSourceBalanceAsync (Uri balanceUri) =>
+            (await GetAsync<BalanceResponse> (balanceUri)).Content;
 
-        internal async Task<BalanceResponse> GetFundingSourceBalanceAsync(Uri balanceUri) =>
-            (await GetAsync<BalanceResponse>(balanceUri)).Content;
+        internal async Task<IavTokenResponse> GetCustomerIavTokenAsync (Uri customerUri) =>
+            (await PostAsync<EmptyResponse, IavTokenResponse> (new Uri (customerUri.AbsoluteUri + "/iav-token"), null)).Content;
 
-        internal async Task<IavTokenResponse> GetCustomerIavTokenAsync(Uri customerUri) =>
-            (await PostAsync<EmptyResponse, IavTokenResponse>(new Uri(customerUri.AbsoluteUri + "/iav-token"), null)).Content;
-
-        internal async Task<Uri> CreateTransferAsync(string sourceFundingSourceId, string destinationFundingSourceId,
-            decimal amount, decimal? fee, Uri chargeTo, string sourceAddenda, string destinationAddenda)
-        {
-            var response = await PostAsync(new Uri($"{_client.ApiBaseAddress}/transfers"),
-                new CreateTransferRequest
-                {
-                    Amount = new Money
-                    {
-                        Currency = "USD",
-                        Value = amount
-                    },
-                    Links = new Dictionary<string, Link>
-                    {
-                        {"source", new Link {Href = new Uri($"{_client.ApiBaseAddress}/funding-sources/{sourceFundingSourceId}")}},
-                        {"destination", new Link {Href = new Uri($"{_client.ApiBaseAddress}/funding-sources/{destinationFundingSourceId}")}}
-                    },
-                    Fees = fee == null || fee == 0m
-                        ? null
-                        : new List<Fee>
-                        {
-                            new Fee
-                            {
-                                Amount = new Money {Value = fee.Value, Currency = "USD"},
-                                Links = new Dictionary<string, Link> {{"charge-to", new Link {Href = chargeTo}}}
+        internal async Task<Uri> CreateTransferAsync (string sourceFundingSourceId, string destinationFundingSourceId,
+            decimal amount, decimal? fee, Uri chargeTo, string sourceAddenda, string destinationAddenda) {
+            var response = await PostAsync (new Uri ($"{_client.ApiBaseAddress}/transfers"),
+                new CreateTransferRequest {
+                    Amount = new Money {
+                            Currency = "USD",
+                                Value = amount
+                        },
+                        Links = new Dictionary<string, Link> { { "source", new Link { Href = new Uri ($"{_client.ApiBaseAddress}/funding-sources/{sourceFundingSourceId}") } },
+                            { "destination", new Link { Href = new Uri ($"{_client.ApiBaseAddress}/funding-sources/{destinationFundingSourceId}") } }
+                        },
+                        Fees = fee == null || fee == 0m ?
+                        null :
+                        new List<Fee> {
+                            new Fee {
+                                Amount = new Money { Value = fee.Value, Currency = "USD" },
+                                    Links = new Dictionary<string, Link> { { "charge-to", new Link { Href = chargeTo } } }
                             }
                         },
-                    AchDetails = sourceAddenda == null || destinationAddenda == null
-                        ? null
-                        : new AchDetails
-                        {
-                            Source = new SourceAddenda
-                            {
-                                Addenda = new Addenda
-                                {
-                                    Values = new List<string> {sourceAddenda}
+                        AchDetails = sourceAddenda == null || destinationAddenda == null ?
+                        null :
+                        new AchDetails {
+                            Source = new SourceAddenda {
+                                    Addenda = new Addenda {
+                                        Values = new List<string> { sourceAddenda }
+                                    }
+                                },
+                                Destination = new DestinationAddenda {
+                                    Addenda = new Addenda {
+                                        Values = new List<string> { destinationAddenda }
+                                    }
                                 }
-                            },
-                            Destination = new DestinationAddenda
-                            {
-                                Addenda = new Addenda
-                                {
-                                    Values = new List<string> {destinationAddenda}
-                                }
-                            }
-                        }                  
+                        }
                 });
             return response.Response.Headers.Location;
         }
 
-        internal async Task<TransferResponse> GetTransferAsync(Uri transferUri) =>
-            (await GetAsync<TransferResponse>(transferUri)).Content;
+        internal async Task<TransferResponse> GetTransferAsync (Uri transferUri) =>
+            (await GetAsync<TransferResponse> (transferUri)).Content;
 
-        internal async Task<TransferResponse> GetTransferAsync(string id) =>
-            (await GetAsync<TransferResponse>(new Uri($"{_client.ApiBaseAddress}/transfers/{id}"))).Content;
+        internal async Task<TransferResponse> GetTransferAsync (string id) =>
+            (await GetAsync<TransferResponse> (new Uri ($"{_client.ApiBaseAddress}/transfers/{id}"))).Content;
 
-        internal async Task<TransferFailureResponse> GetTransferFailureAsync(string id) =>
-            (await GetAsync<TransferFailureResponse>(new Uri($"{_client.ApiBaseAddress}/transfers/{id}/failure"))).Content;
+        internal async Task<TransferFailureResponse> GetTransferFailureAsync (string id) =>
+            (await GetAsync<TransferFailureResponse> (new Uri ($"{_client.ApiBaseAddress}/transfers/{id}/failure"))).Content;
 
-        internal async Task<Uri> CreateWebhookSubscriptionAsync(Uri uri, string url, string secret) =>
-            (await PostAsync(uri, new CreateWebhookSubscriptionRequest {Url = url, Secret = secret})).Response.Headers.Location;
+        internal async Task<Uri> CreateWebhookSubscriptionAsync (Uri uri, string url, string secret) =>
+            (await PostAsync (uri, new CreateWebhookSubscriptionRequest { Url = url, Secret = secret })).Response.Headers.Location;
 
-        internal async Task DeleteWebhookSubscriptionAsync(Uri uri) => await DeleteAsync<object>(uri, null);
+        internal async Task DeleteWebhookSubscriptionAsync (Uri uri) => await DeleteAsync<object> (uri, null);
 
-        internal async Task<WebhookSubscription> GetWebhookSubscriptionAsync(Uri uri) =>
-            (await GetAsync<WebhookSubscription>(uri)).Content;
+        internal async Task<WebhookSubscription> GetWebhookSubscriptionAsync (Uri uri) =>
+            (await GetAsync<WebhookSubscription> (uri)).Content;
 
-        internal async Task<GetWebhookSubscriptionsResponse> GetWebhookSubscriptionsAsync(Uri uri) =>
-            (await GetAsync<GetWebhookSubscriptionsResponse>(uri)).Content;
+        internal async Task<GetWebhookSubscriptionsResponse> GetWebhookSubscriptionsAsync (Uri uri) =>
+            (await GetAsync<GetWebhookSubscriptionsResponse> (uri)).Content;
 
-        internal async Task<GetEventsResponse> GetEventsAsync(Uri uri) =>
-            (await GetAsync<GetEventsResponse>(uri)).Content;
+        internal async Task<GetEventsResponse> GetEventsAsync (Uri uri) =>
+            (await GetAsync<GetEventsResponse> (uri)).Content;
 
-        internal async Task<GetBusinessClassificationsResponse> GetBusinessClassificationsAsync() =>
-            (await GetAsync<GetBusinessClassificationsResponse>(
-                new Uri($"{_client.ApiBaseAddress}/business-classifications"))).Content;
+        internal async Task<GetBusinessClassificationsResponse> GetBusinessClassificationsAsync () =>
+            (await GetAsync<GetBusinessClassificationsResponse> (
+                new Uri ($"{_client.ApiBaseAddress}/business-classifications"))).Content;
 
-        private async Task<RestResponse<TRes>> GetAsync<TRes>(Uri uri) where TRes : IDwollaResponse =>
-            await ExecAsync(() => _client.GetAsync<TRes>(uri, _headers));
+        private async Task<RestResponse<TRes>> GetAsync<TRes> (Uri uri) where TRes : IDwollaResponse =>
+            await ExecAsync (() => _client.GetAsync<TRes> (uri, _headers));
 
-        private async Task<RestResponse<EmptyResponse>> PostAsync<TReq>(Uri uri, TReq request) =>
-            await ExecAsync(() => _client.PostAsync<TReq, EmptyResponse>(uri, request, _headers));
+        private async Task<RestResponse<EmptyResponse>> PostAsync<TReq> (Uri uri, TReq request) =>
+            await ExecAsync (() => _client.PostAsync<TReq, EmptyResponse> (uri, request, _headers));
 
-        private async Task<RestResponse<TRes>> PostAsync<TReq, TRes>(Uri uri, TReq request) where TRes : IDwollaResponse =>
-            await ExecAsync(() => _client.PostAsync<TReq, TRes>(uri, request, _headers));
+        private async Task<RestResponse<TRes>> PostAsync<TReq, TRes> (Uri uri, TReq request) where TRes : IDwollaResponse =>
+            await ExecAsync (() => _client.PostAsync<TReq, TRes> (uri, request, _headers));
 
-        private async Task<RestResponse<EmptyResponse>> DeleteAsync<TReq>(Uri uri, TReq request) =>
-            await ExecAsync(() => _client.DeleteAsync(uri, request, _headers));
+        private async Task<RestResponse<EmptyResponse>> DeleteAsync<TReq> (Uri uri, TReq request) =>
+            await ExecAsync (() => _client.DeleteAsync (uri, request, _headers));
 
-        private static async Task<RestResponse<TRes>> ExecAsync<TRes>(Func<Task<RestResponse<TRes>>> func) where TRes : IDwollaResponse
-        {
-            var r = await func();
+        private static async Task<RestResponse<TRes>> ExecAsync<TRes> (Func<Task<RestResponse<TRes>>> func) where TRes : IDwollaResponse {
+            var r = await func ();
             if (r.Error == null) return r;
 
             // TODO: Handle error specific to your application
             var e = r.Error;
-            Console.WriteLine($"{e.Code}: {e.Message}");
+            Console.WriteLine ($"{e.Code}: {e.Message}");
 
             // To print out the full error response, uncomment the line below
             // Console.WriteLine(JsonConvert.SerializeObject(e, Formatting.Indented));
 
             // Example error handling. More info: https://docsv2.dwolla.com/#errors
-            if (e.Code == "ExpiredAccessToken")
-            {
+            if (e.Code == "ExpiredAccessToken") {
                 // TODO: Refresh token and retry request
             }
 

--- a/ExampleApp/Program.cs
+++ b/ExampleApp/Program.cs
@@ -6,40 +6,42 @@ using System.Threading.Tasks;
 using Dwolla.Client;
 using ExampleApp.Tasks;
 using static System.Console;
+using Dwolla.Client.Models.Requests;
+using Dwolla.Client.Models.Responses;
+using Dwolla.Client.Rest;
 
-namespace ExampleApp
-{
-    public class Program
-    {
-        private static void Main()
-        {
-            var key = Environment.GetEnvironmentVariable("DWOLLA_APP_KEY");
-            var secret = Environment.GetEnvironmentVariable("DWOLLA_APP_SECRET");
+namespace ExampleApp {
+    public class Program {
+        private static void Main () {
+            var key = Environment.GetEnvironmentVariable ("DWOLLA_APP_KEY");
+            var secret = Environment.GetEnvironmentVariable ("DWOLLA_APP_SECRET");
 
-            if (string.IsNullOrWhiteSpace(key) || string.IsNullOrWhiteSpace(secret))
-            {
-                WriteLine("Set DWOLLA_APP_KEY and DWOLLA_APP_SECRET env vars and restart IDE. Press any key to exit..");
-                ReadLine();
-            }
-            else
-            {
+            if (string.IsNullOrWhiteSpace (key) || string.IsNullOrWhiteSpace (secret)) {
+                WriteLine ("Set DWOLLA_APP_KEY and DWOLLA_APP_SECRET env vars and restart IDE. Press any key to exit..");
+                ReadLine ();
+            } else {
                 var running = true;
-                var broker = new DwollaBroker(DwollaClient.Create(true));
+                var client = DwollaClient.Create (true);
+                var broker = new DwollaBroker (client);
 
-                Task.Run(async () => await broker.SetAuthorizationHeader(key, secret)).Wait();
+                var tokenTask = Task.Run (async () =>
+                    await client.PostAuthAsync<TokenResponse>(new AppTokenRequest {
+                        Key = key,
+                        Secret = secret
+                    })
+                );
+                broker.SetBearerAuthorization (tokenTask.Result.Content.Token);
 
-                WriteHelp();
+                WriteHelp ();
 
-                while (running)
-                {
-                    Write("What would you like to do? (Press ? for options): ");
-                    var i = ReadLine();
-                    var input = i == null ? "" : i.ToLower().Trim();
+                while (running) {
+                    Write ("What would you like to do? (Press ? for options): ");
+                    var i = ReadLine ();
+                    var input = i == null ? "" : i.ToLower ().Trim ();
 
-                    switch (input)
-                    {
+                    switch (input) {
                         case "?":
-                            WriteHelp();
+                            WriteHelp ();
                             break;
 
                         case "quit":
@@ -49,50 +51,44 @@ namespace ExampleApp
                             break;
 
                         default:
-                            BeginTask(input, broker);
+                            BeginTask (input, broker);
                             break;
                     }
                 }
             }
         }
 
-        private static void WriteHelp()
-        {
-            WriteLine(@"Options:
+        private static void WriteHelp () {
+            WriteLine (@"Options:
  - Quit (q)
  - Help (?)");
-            GetTasks().ForEach(ta => WriteLine($" - {ta.Description} ({ta.Command})"));
+            GetTasks ().ForEach (ta => WriteLine ($" - {ta.Description} ({ta.Command})"));
         }
 
         private static Dictionary<string, Type> _tasks;
 
-        private static List<TaskAttribute> GetTasks()
-        {
+        private static List<TaskAttribute> GetTasks () {
             if (_tasks == null)
-                _tasks = Assembly.GetEntryAssembly().GetTypes()
-                    .Where(x => typeof(BaseTask).IsAssignableFrom(x) &&
-                                !x.GetTypeInfo().IsAbstract &&
-                                x.GetTypeInfo().GetCustomAttribute<TaskAttribute>() != null)
-                    .ToDictionary(x => x.GetTypeInfo().GetCustomAttribute<TaskAttribute>().Command);
+                _tasks = Assembly.GetEntryAssembly ().GetTypes ()
+                .Where (x => typeof (BaseTask).IsAssignableFrom (x) &&
+                    !x.GetTypeInfo ().IsAbstract &&
+                    x.GetTypeInfo ().GetCustomAttribute<TaskAttribute> () != null)
+                .ToDictionary (x => x.GetTypeInfo ().GetCustomAttribute<TaskAttribute> ().Command);
 
             return _tasks
-                .OrderBy(x => x.Value.FullName)
-                .Select(x => x.Value.GetTypeInfo().GetCustomAttribute<TaskAttribute>())
-                .ToList();
+                .OrderBy (x => x.Value.FullName)
+                .Select (x => x.Value.GetTypeInfo ().GetCustomAttribute<TaskAttribute> ())
+                .ToList ();
         }
 
-        private static void BeginTask(string command, DwollaBroker broker)
-        {
-            if (!_tasks.ContainsKey(command))
-            {
-                WriteLine("Unrecognized option");
-            }
-            else
-            {
+        private static void BeginTask (string command, DwollaBroker broker) {
+            if (!_tasks.ContainsKey (command)) {
+                WriteLine ("Unrecognized option");
+            } else {
                 var type = _tasks[command];
-                var task = (BaseTask) type.GetConstructor(new Type[0]).Invoke(new object[0]);
+                var task = (BaseTask) type.GetConstructor (new Type[0]).Invoke (new object[0]);
                 task.Broker = broker;
-                Task.Run(async () => await task.Run()).Wait();
+                Task.Run (async () => await task.Run ()).Wait ();
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/Dwolla
 
 ## Changelog
 
+- **6.0.0** Add `AuthorizationCodeRequest` and `RefreshTokenRequest` for Partner Integrations auth flow.
 - **5.1.1** Update Content-Type and Accept headers for Token URLs
 - **5.1.0** Change Token URLs
 - **5.0.16** Add missing `using` to ExampleApp

--- a/dwolla-v2-csharp.code-workspace
+++ b/dwolla-v2-csharp.code-workspace
@@ -1,0 +1,12 @@
+{
+  "folders": [
+    {
+      "name": "dwolla-v2-csharp",
+      "path": "."
+    }
+  ],
+  "settings": {
+    "editor.tabSize": 4,
+    "editor.detectIndentation": false
+  }
+}


### PR DESCRIPTION
This adds `AuthorizationCodeRequest` + `RefreshTokenRequest`, and also slightly refactors the `PostAuthAsync<T>` method to not require a URI.

#### `client_credentials` flow

```csharp
await client.PostAuthAsync<TokenResponse>(new AppTokenRequest {
    Key = "client-id",
    Secret ="client-secret"
})
```

#### `authorization_code` flow

```csharp
await client.PostAuthAsync<TokenResponse>(new AuthorizationCodeRequest {
    Key = "client-id",
    Secret ="client-secret",
    RedirectUri = "https://mysite.com/dwolla/callback",
    Code = "code"
})
```

#### `refresh_token` flow

```csharp
await client.PostAuthAsync<TokenResponse>(new RefreshTokenRequest {
    Key = "client-id",
    Secret ="client-secret",
    RefreshToken = "refresh-token"
})
```
