### PR TITLE
Update AchDetails to match July 2022 API change

### DIFF
--- a/Dwolla.Client/Models/AchDetails.cs
+++ b/Dwolla.Client/Models/AchDetails.cs
@@ -1,8 +1,13 @@
 namespace Dwolla.Client.Models
 {
+    public class AchDetailsTrace
+    {
+        public string TraceId { get; set; }
+    }
+    
     public class AchDetails
     {
-        public SourceAddenda Source { get; set; }
-        public DestinationAddenda Destination { get; set; }
+        public AchDetailsTrace Source { get; set; }
+        public AchDetailsTrace Destination { get; set; }
     }
 }


### PR DESCRIPTION
Looks like the AchDetails object was changed around mid-July (https://www.dwolla.com/updates/trace-id-payment-tracking/) and this change does not appear to work with the existing Addenda class.